### PR TITLE
feat(website): add OpenGraph and Twitter Card meta tags for SEO

### DIFF
--- a/website/assets/og-image.svg
+++ b/website/assets/og-image.svg
@@ -1,0 +1,56 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0a0a0f"/>
+      <stop offset="100%" stop-color="#1a1a2e"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#7c3aed"/>
+      <stop offset="100%" stop-color="#6366f1"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bg)"/>
+
+  <!-- Subtle grid -->
+  <g opacity="0.05" stroke="#a78bfa" stroke-width="0.5">
+    <line x1="0" y1="0" x2="0" y2="630"/><line x1="60" y1="0" x2="60" y2="630"/>
+    <line x1="120" y1="0" x2="120" y2="630"/><line x1="180" y1="0" x2="180" y2="630"/>
+    <line x1="240" y1="0" x2="240" y2="630"/><line x1="300" y1="0" x2="300" y2="630"/>
+    <line x1="360" y1="0" x2="360" y2="630"/><line x1="420" y1="0" x2="420" y2="630"/>
+    <line x1="480" y1="0" x2="480" y2="630"/><line x1="540" y1="0" x2="540" y2="630"/>
+    <line x1="600" y1="0" x2="600" y2="630"/><line x1="660" y1="0" x2="660" y2="630"/>
+    <line x1="720" y1="0" x2="720" y2="630"/><line x1="780" y1="0" x2="780" y2="630"/>
+    <line x1="840" y1="0" x2="840" y2="630"/><line x1="900" y1="0" x2="900" y2="630"/>
+    <line x1="960" y1="0" x2="960" y2="630"/><line x1="1020" y1="0" x2="1020" y2="630"/>
+    <line x1="1080" y1="0" x2="1080" y2="630"/><line x1="1140" y1="0" x2="1140" y2="630"/>
+    <line x1="0" y1="60" x2="1200" y2="60"/><line x1="0" y1="120" x2="1200" y2="120"/>
+    <line x1="0" y1="180" x2="1200" y2="180"/><line x1="0" y1="240" x2="1200" y2="240"/>
+    <line x1="0" y1="300" x2="1200" y2="300"/><line x1="0" y1="360" x2="1200" y2="360"/>
+    <line x1="0" y1="420" x2="1200" y2="420"/><line x1="0" y1="480" x2="1200" y2="480"/>
+    <line x1="0" y1="540" x2="1200" y2="540"/>
+  </g>
+
+  <!-- Logo icon (scaled up from favicon) -->
+  <g transform="translate(100, 220) scale(5)">
+    <circle cx="11" cy="13" r="3" fill="#7c3aed"/>
+    <circle cx="21" cy="13" r="3" fill="#a78bfa"/>
+    <circle cx="16" cy="22" r="3" fill="#6366f1"/>
+    <line x1="11" y1="13" x2="21" y2="13" stroke="#7c3aed" stroke-width="1.5" opacity="0.5"/>
+    <line x1="11" y1="13" x2="16" y2="22" stroke="#7c3aed" stroke-width="1.5" opacity="0.5"/>
+    <line x1="21" y1="13" x2="16" y2="22" stroke="#a78bfa" stroke-width="1.5" opacity="0.5"/>
+  </g>
+
+  <!-- Title -->
+  <text x="340" y="290" font-family="Inter, system-ui, sans-serif" font-size="72" font-weight="800" fill="#f0f0f5">Polyphony</text>
+
+  <!-- Tagline -->
+  <text x="340" y="350" font-family="Inter, system-ui, sans-serif" font-size="28" font-weight="400" fill="#a78bfa">Orchestrate AI Agents from Your Terminal</text>
+
+  <!-- URL -->
+  <text x="340" y="410" font-family="JetBrains Mono, monospace" font-size="20" font-weight="400" fill="#6b7280">www.polyphony.to</text>
+
+  <!-- Accent line at bottom -->
+  <rect x="0" y="620" width="1200" height="10" fill="url(#accent)"/>
+</svg>

--- a/website/index.html
+++ b/website/index.html
@@ -7,11 +7,28 @@
   <title>Polyphony — Orchestrate AI Agents from Your Terminal</title>
   <meta name="description" content="Connect your issue tracker, dispatch AI coding agents, and watch them work — all from a single TUI dashboard.">
   <link rel="canonical" href="https://www.polyphony.to/">
+  <!-- Open Graph -->
   <meta property="og:url" content="https://www.polyphony.to/">
   <meta property="og:title" content="Polyphony — Orchestrate AI Agents from Your Terminal">
   <meta property="og:description" content="Connect your issue tracker, dispatch AI coding agents, and watch them work — from a terminal dashboard or the web.">
   <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Polyphony">
+  <meta property="og:locale" content="en_US">
+  <meta property="og:image" content="https://www.polyphony.to/assets/og-image.svg">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:alt" content="Polyphony — Orchestrate AI Agents from Your Terminal">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Polyphony — Orchestrate AI Agents from Your Terminal">
+  <meta name="twitter:description" content="Connect your issue tracker, dispatch AI coding agents, and watch them work — from a terminal dashboard or the web.">
+  <meta name="twitter:image" content="https://www.polyphony.to/assets/og-image.svg">
+  <meta name="twitter:image:alt" content="Polyphony — Orchestrate AI Agents from Your Terminal">
+
+  <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="apple-touch-icon" href="assets/favicon.svg">
 
   <!-- Theme: prevent FOUC -->
   <script>


### PR DESCRIPTION
Add og:image, og:site_name, og:locale, and full Twitter Card tags
so links shared on social platforms display a rich preview with the
Polyphony branding. Also adds an OG social card image (1200x630 SVG)
using the existing logo/icon design and an apple-touch-icon link.

https://claude.ai/code/session_01TUEjStQKofGz9ttqigPsMo